### PR TITLE
Fixed Critical Device Config Bitmask Bug

### DIFF
--- a/Applications/deviceconfiguration/deviceconfiguration.py
+++ b/Applications/deviceconfiguration/deviceconfiguration.py
@@ -106,8 +106,8 @@ def unitconfig():
                 device_gps_dict['DEFAULT_LONGITUDE'], device_gps_dict['DEFAULT_LONGITUDE_DIRECTION'],
                 device_gps_dict['DEFAULT_ALTITUDE'], device_gps_dict['DEFAULT_ALTITUDE_UNITS'])
             device_config_object.update_telemetry(device_config_object.update_bitmask_telemetry_boot(
-                int(device_telemetry_dict['UART_TELEMETRY_BOOT_BIT']),
-                int(device_telemetry_dict['RF_TELEMETRY_BOOT_BIT'])),
+                int(device_telemetry_dict['RF_TELEMETRY_BOOT_BIT']),
+                int(device_telemetry_dict['UART_TELEMETRY_BOOT_BIT'])),
                 int(device_telemetry_dict['TELEMETRY_DEFAULT_UART_INTERVAL']),
                 int(device_telemetry_dict['TELEMETRY_DEFAULT_RF_INTERVAL']))
 


### PR DESCRIPTION
I found that the bitmask had been programming units with RF and UART
telemetry enable bits backwards. Thus UART was OFF and RF ON when
opposite was desired.

Verified working, TELEMETRY from .db below:


"288"	"KB1LQD"	"1"	"KB1LQD"	"1"	"32"	"0"	"0"	"1"	"4"	"1"	"45575"	"012345678"	"N"	"0123456789"	"W"	"0.0"	"M"	"0.0"	"0"	"0.0"	"192"	"0"	"2381"	"2247"	"2279"	"2194"	"2099"	"2087"	"0"	"25"	"2846"	"0"	"0"	"7200"	"0"	"1486355869.485"

