### PR TITLE
Firmware revision variable telemetry support

### DIFF
--- a/Faraday_Proxy_Tools/FaradayIO/telemetryparser.py
+++ b/Faraday_Proxy_Tools/FaradayIO/telemetryparser.py
@@ -12,7 +12,7 @@ class TelemetryParse(object):
         self.flash_config_info_d_struct_len = 116
         self.packet_1_struct = struct.Struct('4B')
         self.packet_1_len = 4
-        self.packet_2_struct = struct.Struct('<1H 12B 4s')
+        self.packet_2_struct = struct.Struct('<1H 12B L')
         self.packet_2_len = 18
         self.packet_3_struct = struct.Struct('>9s 2B 9s 8B 1H 9s 1s 10s 1s 8s 1s 5s 1c 4s 3B 9H 2B 2H')
         self.packet_3_len = 97

--- a/Faraday_Proxy_Tools/FaradayIO/telemetryparser.py
+++ b/Faraday_Proxy_Tools/FaradayIO/telemetryparser.py
@@ -12,8 +12,8 @@ class TelemetryParse(object):
         self.flash_config_info_d_struct_len = 116
         self.packet_1_struct = struct.Struct('4B')
         self.packet_1_len = 4
-        self.packet_2_struct = struct.Struct('<1H 12B')
-        self.packet_2_len = 14
+        self.packet_2_struct = struct.Struct('<1H 12B 4s')
+        self.packet_2_len = 18
         self.packet_3_struct = struct.Struct('>9s 2B 9s 8B 1H 9s 1s 10s 1s 8s 1s 5s 1c 4s 3B 9H 2B 2H')
         self.packet_3_len = 97
 
@@ -267,6 +267,7 @@ class TelemetryParse(object):
             Index[10]: FLL Unlock counter
             Index[11]: Peripheral / Config counter
             Index[12]: Access violation counter
+            Index[13]: Firmware Revision
         """
         #Unpack the packet
         parsed_packet = self.packet_2_struct.unpack(packet)
@@ -284,6 +285,7 @@ class TelemetryParse(object):
                           'FLLUnlockCounter': parsed_packet[10],
                           'PeripheralConfigCounter': parsed_packet[11],
                           'AccessViolationCounter': parsed_packet[12],
+                          'FirmwareRevision': parsed_packet[13],
                           }
 
         #Perform debug actions if needed
@@ -302,6 +304,7 @@ class TelemetryParse(object):
             print "Index[10]: FLL Unlock counter", dictionaryData['FLLUnlockCounter']
             print "Index[11]: Peripheral / Config counter", dictionaryData['PeripheralConfigCounter']
             print "Index[12]: Access violation counter", dictionaryData['AccessViolationCounter']
+            print "Index[13]: Firmware Revision", dictionaryData['FirmwareRevision'], repr(dictionaryData['FirmwareRevision'])
         else:
             pass
 

--- a/Tutorials/Tutorials/1-Basic_Proxy_Interactions_And_Programming/2-Telemetry-Parsing/Tutorial_Telemetry_Parsing.py
+++ b/Tutorials/Tutorials/1-Basic_Proxy_Interactions_And_Programming/2-Telemetry-Parsing/Tutorial_Telemetry_Parsing.py
@@ -11,8 +11,8 @@ from FaradayIO import cc430radioconfig
 
 
 #Variables
-local_device_callsign = 'kb1lqd' # Should match the connected Faraday unit as assigned in Proxy configuration
-local_device_node_id = 2 # Should match the connected Faraday unit as assigned in Proxy configuration
+local_device_callsign = 'REPLACEME' # Should match the connected Faraday unit as assigned in Proxy configuration
+local_device_node_id = REPLACEME # Should match the connected Faraday unit as assigned in Proxy configuration
 
 #Start the proxy server after configuring the configuration file correctly
 #Setup a Faraday IO object
@@ -71,7 +71,7 @@ rx_debug_data_datagram = faraday_parser.UnpackDatagram(rx_debug_data_pkt_decoded
 rx_debug_data_packet = rx_debug_data_datagram['PayloadData']
 
 #Extract the exact debug packet from longer datagram payload (Telemetry Packet #2)
-rx_debug_data_pkt_extracted = faraday_parser.ExtractPaddedPacket(rx_debug_data_pkt_decoded, faraday_parser.packet_2_len)
+rx_debug_data_pkt_extracted = faraday_parser.ExtractPaddedPacket(rx_debug_data_packet, faraday_parser.packet_2_len)
 
 #Parse the Telemetry #3 packet
 rx_debug_data_parsed = faraday_parser.UnpackPacket_2(rx_debug_data_pkt_extracted, debug = True) #Debug ON


### PR DESCRIPTION
* I added support to the telemetry parsing function for debug flash data to support the added firmware revision field
* Fixed a bug found in the tutorial for telemetry parsing caused by incorrect variable use that resulted in a displayed byte shift of data in final print to screen.