### PR TITLE
Pad callsign for APRS passcode generation.

### DIFF
--- a/Applications/APRS/aprs.py
+++ b/Applications/APRS/aprs.py
@@ -876,6 +876,8 @@ def generatePasscode(callsign):
 
     # Convert callsign to list and obtain length
     callList = list(callsign)
+    if len(callList) % 2 != 0:
+        callList.append('\0')
     length = len(callList)
 
     # Perform hash if length is valid


### PR DESCRIPTION
The APRS passcode generation algorithm reads the callsign two bytes at
a time. Pad the callsign to an even number of bytes.