### PR TITLE
Basic Typographical and Gramatical Fixes to SimpleUI/readme.md

### DIFF
--- a/Applications/SimpleUI/readme.md
+++ b/Applications/SimpleUI/readme.md
@@ -1,10 +1,10 @@
 # Simple UI
 This is a basic user interface to interact with the Faraday radios whether local or remote. It is based on Flask and Jquery/Bootstrap to provide a simplistic experience. Simple UI is usable for general commanding and monitoring of live data as well as basic High Altitude Balloon flights.
 
-A secondary goal of having a basic user interface that can be used to show how python/javascript are used to create a simple interfae was also achieved with this program.
+A secondary goal of having a basic user interface that can be used to show how python/javascript are used to create a simple interface was also achieved with this program.
 
 # Software Requirements
-In order for SimpleUI to operation one must have the following programs running in the background:
+In order for SimpleUI to operate, one must have the following programs running in the background:
 - Proxy
 - Telemetry
 
@@ -40,7 +40,7 @@ This configuration file also contains the following:
  * `PORT` Network port to serve
 
 # Running Simple UI
-## Windoews
+## Windows
 ### Command Line
 1. Navigate to SimpleUI folder i.e. `cd C:\git\faradayrf\software\SimpleUI`
 2. Open simpleui.py with python `python simpleui.py`


### PR DESCRIPTION
Changed "interfae" to "interface" (line 4)
Changed "In order for SimpleUI to operation" to "In order for SimpleUI
to operate," (line 7)
Changed "Windoews" to "Windows" (line 43)

After stumbling around git for a little while, I think I got this right. Please let me know if there's anything wrong, or that I should do differently in the future.