### PR TITLE
Added try/except statement for units config

### DIFF
--- a/faraday/proxy.py
+++ b/faraday/proxy.py
@@ -585,7 +585,7 @@ def main():
         units = callsign2COM()
     except ConfigParser.NoSectionError as e:
         logging.error(e)
-        sys.exit()
+        sys.exit(1) #  Status Code 1 = Config Error
 
     if testmode == 0:
         for key, values in units.iteritems():

--- a/faraday/proxy.py
+++ b/faraday/proxy.py
@@ -581,7 +581,12 @@ def main():
 
     # Associate serial ports with callsigns
     # global units
-    units = callsign2COM()
+    try:
+        units = callsign2COM()
+
+    except ConfigParser.NoSectionError as e:
+        logging.error(e)
+        sys.exit()
 
     if testmode == 0:
         for key, values in units.iteritems():

--- a/faraday/proxy.py
+++ b/faraday/proxy.py
@@ -585,7 +585,7 @@ def main():
         units = callsign2COM()
     except ConfigParser.NoSectionError as e:
         logging.error(e)
-        sys.exit(1) #  Status Code 1 = Config Error
+        sys.exit(1)  # Status Code 1 = Config Error
 
     if testmode == 0:
         for key, values in units.iteritems():

--- a/faraday/proxy.py
+++ b/faraday/proxy.py
@@ -583,7 +583,6 @@ def main():
     # global units
     try:
         units = callsign2COM()
-
     except ConfigParser.NoSectionError as e:
         logging.error(e)
         sys.exit()


### PR DESCRIPTION
When creating appropriate items based on proxy.ini configuration file
sections a new try/except statement catches the
ConfigParser.NoSectionsError. When the exception is caught it logs the
error and exits python.

This addresses and fixes issue #132.