### PR TITLE
Fix Master to Run From Command Line

### DIFF
--- a/faraday/aprs.py
+++ b/faraday/aprs.py
@@ -14,16 +14,21 @@ import threading
 import ConfigParser
 import socket
 import requests
+import os
 from time import sleep
 
 # Start logging after importing modules
-logging.config.fileConfig('loggingConfig.ini')
+dir = os.path.dirname(__file__)
+logConfig = os.path.join(dir,"..","Applications","APRS","loggingConfig.ini")
+logging.config.fileConfig(logConfig)
 logger = logging.getLogger('APRS')
 
 # Load Telemetry Configuration from telemetry.ini file
 # Should have common file for apps...
 aprsConfig = ConfigParser.RawConfigParser()
-aprsConfig.read('aprs.ini')
+dir = os.path.dirname(__file__)
+fileName = os.path.join(dir,"..","Applications","APRS","aprs.ini")
+aprsConfig.read(fileName)
 
 # Create and initialize dictionary queues
 telemetryDicts = {}

--- a/faraday/aprs.py
+++ b/faraday/aprs.py
@@ -19,7 +19,7 @@ from time import sleep
 
 # Start logging after importing modules
 dir = os.path.dirname(__file__)
-logConfig = os.path.join(dir,"..","Applications","APRS","loggingConfig.ini")
+logConfig = os.path.join(dir, "..", "Applications", "APRS", "loggingConfig.ini")
 logging.config.fileConfig(logConfig)
 logger = logging.getLogger('APRS')
 
@@ -27,7 +27,7 @@ logger = logging.getLogger('APRS')
 # Should have common file for apps...
 aprsConfig = ConfigParser.RawConfigParser()
 dir = os.path.dirname(__file__)
-fileName = os.path.join(dir,"..","Applications","APRS","aprs.ini")
+fileName = os.path.join(dir, "..", "Applications", "APRS", "aprs.ini")
 aprsConfig.read(fileName)
 
 # Create and initialize dictionary queues

--- a/faraday/proxy.py
+++ b/faraday/proxy.py
@@ -478,7 +478,6 @@ def openTestDB():
         testDbFilename = proxyConfig.get("TESTDATABASE", "FILENAME")
         testDbFilename = os.path.join(dir, "..", "Proxy", testDbFilename)
 
-
     except ConfigParser.Error as e:
         logger.error("ConfigParse.Error: " + str(e))
         return None

--- a/faraday/proxy.py
+++ b/faraday/proxy.py
@@ -26,14 +26,15 @@ from flask import request
 from faraday.uart import layer_4_service
 
 # Start logging after importing modules
-filename = os.path.abspath("Proxy/loggingConfig.ini")
-print filename
-logging.config.fileConfig(filename)
+dir = os.path.dirname(__file__)
+logConfig = os.path.join(dir, "..", "Proxy", "loggingConfig.ini")
+logging.config.fileConfig(logConfig)
 logger = logging.getLogger('Proxy')
 
 # Load Proxy Configuration from proxy.ini file
 proxyConfig = ConfigParser.RawConfigParser()
-filename = os.path.abspath("Proxy/proxy.ini")
+dir = os.path.dirname(__file__)
+filename = os.path.join(dir, "..", "Proxy", "proxy.ini")
 proxyConfig.read(filename)
 
 # Create and initialize dictionary queues
@@ -431,10 +432,13 @@ def initDB():
 
     # Obtain configuration file names
     try:
+        dir = os.path.dirname(__file__)
         dbFilename = proxyConfig.get("DATABASE", "FILENAME")
-        dbFilename = os.path.join('Proxy', dbFilename)
+        dbFilename = os.path.join(dir, "..", "Proxy", dbFilename)
+
+        dir = os.path.dirname(__file__)
         dbSchema = proxyConfig.get("DATABASE", "SCHEMANAME")
-        dbSchema = os.path.join('Proxy', dbSchema)
+        dbSchema = os.path.join(dir, "..", "Proxy", dbSchema)
 
     except ConfigParser.Error as e:
         logger.error("ConfigParse.Error: " + str(e))
@@ -470,7 +474,10 @@ def openTestDB():
 
     # Obtain configuration file names
     try:
+        dir = os.path.dirname(__file__)
         testDbFilename = proxyConfig.get("TESTDATABASE", "FILENAME")
+        testDbFilename = os.path.join(dir, "..", "Proxy", testDbFilename)
+
 
     except ConfigParser.Error as e:
         logger.error("ConfigParse.Error: " + str(e))
@@ -526,7 +533,9 @@ def sqlInsert(data):
 
     # Read in name of database
     try:
+        dir = os.path.dirname(__file__)
         db = proxyConfig.get("DATABASE", "FILENAME")
+        db = os.path.join(dir, "..", "Proxy", db)
 
     except ConfigParser.Error as e:
         logger.error("ConfigParse.Error: " + str(e))

--- a/faraday/proxy.py
+++ b/faraday/proxy.py
@@ -26,13 +26,14 @@ from flask import request
 from faraday.uart import layer_4_service
 
 # Start logging after importing modules
-filename = os.path.abspath("loggingConfig.ini")
+filename = os.path.abspath("Proxy/loggingConfig.ini")
+print filename
 logging.config.fileConfig(filename)
 logger = logging.getLogger('Proxy')
 
 # Load Proxy Configuration from proxy.ini file
 proxyConfig = ConfigParser.RawConfigParser()
-filename = os.path.abspath("proxy.ini")
+filename = os.path.abspath("Proxy/proxy.ini")
 proxyConfig.read(filename)
 
 # Create and initialize dictionary queues
@@ -431,7 +432,9 @@ def initDB():
     # Obtain configuration file names
     try:
         dbFilename = proxyConfig.get("DATABASE", "FILENAME")
+        dbFilename = os.path.join('Proxy', dbFilename)
         dbSchema = proxyConfig.get("DATABASE", "SCHEMANAME")
+        dbSchema = os.path.join('Proxy', dbSchema)
 
     except ConfigParser.Error as e:
         logger.error("ConfigParse.Error: " + str(e))

--- a/faraday/simpleui.py
+++ b/faraday/simpleui.py
@@ -27,19 +27,24 @@ from faraday.proxyio import faradaycommands
 from faraday.proxyio import gpioallocations
 
 # Start logging after importing modules
-filename = os.path.abspath("loggingConfig.ini")
-logging.config.fileConfig(filename)
+dir = os.path.dirname(__file__)
+logConfig = os.path.join(dir,"..","Applications","SimpleUI","loggingConfig.ini")
+logging.config.fileConfig(logConfig)
 logger = logging.getLogger('SimpleUI')
 
 # Load configuration file
 simpleuiconfig = ConfigParser.RawConfigParser()
-filename = os.path.abspath("simpleui.ini")
+dir = os.path.dirname(__file__)
+filename = os.path.join(dir,"..","Applications","SimpleUI","simpleui.ini")
 simpleuiconfig.read(filename)
 
 # Initialize Flask microframework
+dir = os.path.dirname(__file__)
+static = os.path.join(dir,"..","Applications","SimpleUI","static")
+templates = os.path.join(dir,"..","Applications","SimpleUI","templates")
 app = Flask(__name__,
-            static_folder='../Applications/SimpleUI/static',
-            template_folder='../Applications/SimpleUI/templates')
+            static_folder=static,
+            template_folder=templates)
 
 
 @app.route('/', methods=['GET', 'POST'])

--- a/faraday/simpleui.py
+++ b/faraday/simpleui.py
@@ -28,20 +28,20 @@ from faraday.proxyio import gpioallocations
 
 # Start logging after importing modules
 dir = os.path.dirname(__file__)
-logConfig = os.path.join(dir,"..","Applications","SimpleUI","loggingConfig.ini")
+logConfig = os.path.join(dir, "..", "Applications", "SimpleUI", "loggingConfig.ini")
 logging.config.fileConfig(logConfig)
 logger = logging.getLogger('SimpleUI')
 
 # Load configuration file
 simpleuiconfig = ConfigParser.RawConfigParser()
 dir = os.path.dirname(__file__)
-filename = os.path.join(dir,"..","Applications","SimpleUI","simpleui.ini")
+filename = os.path.join(dir, "..", "Applications", "SimpleUI", "simpleui.ini")
 simpleuiconfig.read(filename)
 
 # Initialize Flask microframework
 dir = os.path.dirname(__file__)
-static = os.path.join(dir,"..","Applications","SimpleUI","static")
-templates = os.path.join(dir,"..","Applications","SimpleUI","templates")
+static = os.path.join(dir, "..", "Applications", "SimpleUI", "static")
+templates = os.path.join(dir, "..", "Applications", "SimpleUI", "templates")
 app = Flask(__name__,
             static_folder=static,
             template_folder=templates)

--- a/faraday/telemetry.py
+++ b/faraday/telemetry.py
@@ -27,7 +27,9 @@ from faraday.proxyio import telemetryparser
 
 # Start logging after importing modules
 try:
-    logging.config.fileConfig('loggingConfig.ini')
+    dir = os.path.dirname(__file__)
+    logConfig = os.path.join(dir,"..","Applications","Telemetry","loggingConfig.ini")
+    logging.config.fileConfig(logConfig)
     logger = logging.getLogger('telemetry')
 
 except ConfigParser.Error as e:
@@ -38,7 +40,9 @@ except ConfigParser.Error as e:
 
 # Load Telemetry Configuration from telemetry.ini file
 telemetryConfig = ConfigParser.RawConfigParser()
-telemetryFile = telemetryConfig.read('telemetry.ini')
+dir = os.path.dirname(__file__)
+telemConfig = os.path.join(dir,"..","Applications","Telemetry","telemetry.ini")
+telemetryFile = telemetryConfig.read(telemConfig)
 
 if len(telemetryFile) == 0:
     #  File missing, indicate error and infinite loop
@@ -440,8 +444,13 @@ def initDB():
 
     # Obtain configuration file names
     try:
+        dir = os.path.dirname(__file__)
         dbFilename = telemetryConfig.get("DATABASE", "FILENAME")
+        dbFilename = os.path.join(dir, "..", "Applications", "Telemetry", dbFilename)
+
+        dir = os.path.dirname(__file__)
         dbSchema = telemetryConfig.get("DATABASE", "SCHEMANAME")
+        dbSchema = os.path.join(dir, "..", "Applications", "Telemetry", dbSchema)
 
     except ConfigParser.Error as e:
         logger.error("ConfigParse.Error: " + str(e))
@@ -539,7 +548,9 @@ def sqlInsert(data):
 
     # Read in name of telemetry database
     try:
+        dir = os.path.dirname(__file__)
         db = telemetryConfig.get("DATABASE", "FILENAME")
+        db = os.path.join(dir, "..", "Applications", "Telemetry", db)
 
     except ConfigParser.Error as e:
         logger.error("ConfigParse.Error: " + str(e))
@@ -650,7 +661,9 @@ def queryDb(parameters):
 
     # Open configuration file
     try:
+        dir = os.path.dirname(__file__)
         dbFilename = telemetryConfig.get("DATABASE", "FILENAME")
+        dbFilename = os.path.join(dir, "..", "Applications", "Telemetry", dbFilename)
 
     except ConfigParser.Error as e:
         logger.error("ConfigParse.Error: " + str(e))
@@ -754,7 +767,9 @@ def queryStationsDb(parameters):
 
     # Get telemetry database name from configuration file
     try:
+        dir = os.path.dirname(__file__)
         dbFilename = telemetryConfig.get("DATABASE", "FILENAME")
+        dbFilename = os.path.join(dir, "..", "Applications", "Telemetry", dbFilename)
 
     except ConfigParser.Error as e:
         logger.error("ConfigParse.Error: " + str(e))

--- a/faraday/telemetry.py
+++ b/faraday/telemetry.py
@@ -28,7 +28,7 @@ from faraday.proxyio import telemetryparser
 # Start logging after importing modules
 try:
     dir = os.path.dirname(__file__)
-    logConfig = os.path.join(dir,"..","Applications","Telemetry","loggingConfig.ini")
+    logConfig = os.path.join(dir, "..", "Applications", "Telemetry", "loggingConfig.ini")
     logging.config.fileConfig(logConfig)
     logger = logging.getLogger('telemetry')
 
@@ -41,7 +41,7 @@ except ConfigParser.Error as e:
 # Load Telemetry Configuration from telemetry.ini file
 telemetryConfig = ConfigParser.RawConfigParser()
 dir = os.path.dirname(__file__)
-telemConfig = os.path.join(dir,"..","Applications","Telemetry","telemetry.ini")
+telemConfig = os.path.join(dir, "..", "Applications", "Telemetry", "telemetry.ini")
 telemetryFile = telemetryConfig.read(telemConfig)
 
 if len(telemetryFile) == 0:


### PR DESCRIPTION
Master has been broken for a few days. Honestly not sure how it happened and we could use blame to figure out but not really worth the time. Likely some confusion on moving to packages.

**Problem**: You couldn't run Faraday Master Software from the command line by calling 

- `python Proxy/proxy.py`
- `python Applications/Telemetry/telemetry.py`
- `python Applications/APRS/aprs.py`
- `python Applications/SimpleUI/simpleui.py`

**Solution**: I added `os.path` imports to use the `__file__` path which uses the directory the module was imported from as the starting point. This would be the `faraday` folder in all current cases. This should also future proof us and make it easier for packaging modules as we're currently having a heck of time moving to them!

I did not bother update any other applications at this time in effort to get this right for packaging. One step at a time.