### PR TITLE
Fix telemetrydb.sql setuptools configuration for Issue #216

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -10,7 +10,7 @@ summary = FaradayRF amateur radio open source software
 description-file = README
 home-page = https://github.com/FaradayRF/Faraday-Software
 license = GPLv3
-version = 0.0.1013
+version = 0.0.101
 classifier =
     "Development Status :: 2 - Pre-Alpha"
     "Framework :: Flask"
@@ -45,6 +45,7 @@ data_files =
         etc/faraday/loggingConfig.ini
         etc/faraday/db.sql
         etc/faraday/telemetry.sample.ini
+        etc/faraday/telemetrydb.sql
         etc/faraday/aprs.sample.ini
         etc/faraday/simpleui.sample.ini
         

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,7 +10,7 @@ summary = FaradayRF amateur radio open source software
 description-file = README
 home-page = https://github.com/FaradayRF/Faraday-Software
 license = GPLv3
-version = 0.0.101
+version = 0.0.1013
 classifier =
     "Development Status :: 2 - Pre-Alpha"
     "Framework :: Flask"


### PR DESCRIPTION
Issue #216 points out that `etc/faraday/telemetrydb.sql` in the faraday package was never being copied to the users computer at `etc/faraday`. This resulted in the inability to create a new database when one one not present in the `~/.faraday/` folder.

Simply adding the file to setup.cfg is all that's needed!

The resulting package for pip will be `faraday-0.0.1013.dev1043-py2-none-any.whl`