### PR TITLE
Add `--start` Option to all Applications (Also Clean Code)

### DIFF
--- a/faraday/aprs.py
+++ b/faraday/aprs.py
@@ -37,9 +37,7 @@ for location in os.curdir, relpath1, relpath2, setuppath, userpath:
 
 logger = logging.getLogger('APRS')
 
-# Load Telemetry Configuration from telemetry.ini file
-
-#Create Proxy configuration file path
+#Create APRS configuration file path
 aprsConfigPath = os.path.join(path, "aprs.ini")
 logger.debug('aprs.ini PATH: ' + aprsConfigPath)
 
@@ -150,7 +148,7 @@ if args.init:
     initializeAPRSConfig()
 configureAPRS(args, aprsConfigPath)
 
-# Read in telemetry configuration parameters
+# Read in APRS configuration parameters
 aprsFile = aprsConfig.read(aprsConfigPath)
 
 # Check for --start option and exit if not present

--- a/faraday/aprs.py
+++ b/faraday/aprs.py
@@ -44,9 +44,6 @@ logger.debug('aprs.ini PATH: ' + aprsConfigPath)
 aprsConfig = ConfigParser.RawConfigParser()
 aprsConfig.read(aprsConfigPath)
 
-# Create and initialize dictionary queues
-telemetryDicts = {}
-
 # Command line input
 parser = argparse.ArgumentParser(description='APRS application queries Faraday telemetry server and uploads data to APRS-IS')
 parser.add_argument('--init-config', dest='init', action='store_true', help='Initialize APRS configuration file')

--- a/faraday/aprs.py
+++ b/faraday/aprs.py
@@ -59,6 +59,7 @@ parser.add_argument('--rate', help='Set APRS-IS update rate in seconds')
 parser.add_argument('--stationsage', help='Set age station date can be to send to APRS-IS in seconds')
 parser.add_argument('--comment', help='Set APRS comment for nodes, use quotes (43 characters maximum)')
 parser.add_argument('--altcomment', help='Set APRS alternate comment for access points, use quotes (43 characters maximum)')
+parser.add_argument('--start', action='store_true', help='Start APRS server')
 
 # Parse the arguments
 args = parser.parse_args()
@@ -151,6 +152,11 @@ configureAPRS(args, aprsConfigPath)
 
 # Read in telemetry configuration parameters
 aprsFile = aprsConfig.read(aprsConfigPath)
+
+# Check for --start option and exit if not present
+if not args.start:
+    logger.warning("--start option not present, exiting APRS server!")
+    sys.exit(0)
 
 
 def getStations():

--- a/faraday/deviceconfiguration.py
+++ b/faraday/deviceconfiguration.py
@@ -58,7 +58,7 @@ deviceConfig = ConfigParser.RawConfigParser()
 parser = argparse.ArgumentParser(description='Device Configuration application provides a Flask server to program Faraday radios via an API')
 parser.add_argument('--init-config', dest='init', action='store_true', help='Initialize Device Configuration configuration file')
 parser.add_argument('--init-faraday-config', dest='initfaraday', action='store_true', help='Initialize Faraday configuration file')
-parser.add_argument('--start', action='store_true', help='Start device configuration server')
+parser.add_argument('--start', action='store_true', help='Start Device Configuration server')
 parser.add_argument('--proxycallsign', help='Set Proxy Faraday callsign to connect to and program')
 parser.add_argument('--proxynodeid', type=int, help='Set Proxy Faraday nodeid to connect to and program')
 parser.add_argument('--faradayconfig', action='store_true', help='Display Faraday configuration file contents')
@@ -399,10 +399,9 @@ if not os.path.isfile(faradayConfigPath):
 # Configure configuration file
 configureDeviceConfiguration(args, deviceConfigurationConfigPath, faradayConfigPath)
 
-# Check if server is to be started
+# Check for --start option and exit if not present
 if not args.start:
-    logger.info("Device configuration exiting!")
-    logger.info("run with --start to start server application")
+    logger.warning("--start option not present, exiting Device Configuration server!")
     sys.exit(0)
 
 # Load configuration from deviceconfiguration.ini file
@@ -586,14 +585,14 @@ def unitconfig():
 
 
 def main():
-    """Main function which starts telemetry worker thread + Flask server."""
-    logger.info('Starting device configuration server')
+    """Main function which starts deviceconfiguration Flask server."""
+    logger.info('Starting deviceconfiguration server')
 
-    # Start the flask server on localhost:8001
-    telemetryhost = deviceConfig.get("FLASK", "HOST")
-    telemetryport = deviceConfig.getint("FLASK", "PORT")
+    # Start the flask server
+    deviceConfigHost = deviceConfig.get("FLASK", "HOST")
+    deviceConfigPort = deviceConfig.getint("FLASK", "PORT")
 
-    app.run(host=telemetryhost, port=telemetryport, threaded=True)
+    app.run(host=deviceConfigHost, port=deviceConfigPort, threaded=True)
 
 
 if __name__ == '__main__':

--- a/faraday/proxy.py
+++ b/faraday/proxy.py
@@ -45,6 +45,11 @@ for location in os.curdir, relpath1, relpath2, setuppath, userpath:
 
 logger = logging.getLogger('Proxy')
 
+# Set werkzeug logging level
+
+werkzeuglog = logging.getLogger('werkzeug')
+werkzeuglog.setLevel(logging.ERROR)
+
 #Create Proxy configuration file path
 proxyConfigPath = os.path.join(path, "proxy.ini")
 logger.debug('Proxy.ini PATH: ' + proxyConfigPath)
@@ -374,6 +379,7 @@ def testdb_read_worker():
 
 # Initialize Flask microframework
 app = Flask(__name__)
+
 
 
 @app.route('/', methods=['GET', 'POST'])

--- a/faraday/proxy.py
+++ b/faraday/proxy.py
@@ -452,7 +452,8 @@ def proxy():
         # present, create port queue for it and append data to that queue
         try:
             data["data"]
-        except:
+
+        except KeyError:
             logger.error("Error: No 'data' key in dictionary")
             return json.dumps(
                 {"error": "Error: No 'data' key in dictionary"}), 400

--- a/faraday/proxy.py
+++ b/faraday/proxy.py
@@ -78,7 +78,7 @@ parser.add_argument('--schema', help='Set Faraday database schema')
 parser.add_argument('--test-database', dest='testdatabase', help='Set Faraday test mode database')
 parser.add_argument('--init-log', dest='initlog', action='store_true', help='Initialize Proxy log database')
 parser.add_argument('--save-log', dest='savelog', help='Save Proxy log database into new SAVELOG file')
-parser.add_argument('--showlogs', action='store_true', help='Show Proxy log database files')
+parser.add_argument('--show-logs', action='store_true', help='Show Proxy log database files')
 
 # Proxy Flask options
 parser.add_argument('--flask-host', dest='flaskhost', help='Set Faraday Flask server host address')

--- a/faraday/proxy.py
+++ b/faraday/proxy.py
@@ -567,7 +567,7 @@ def proxy():
                     {'Content-Type': 'application/json'}
             else:
                 # No data in service port, but port is being used
-                logger.info("Empty buffer for port %d", port)
+                logger.info("Empty buffer for port {0}".format(port))
                 return '', 204  # HTTP 204 response cannot have message data
 
         except ValueError as e:
@@ -803,7 +803,7 @@ def main():
             unitDict[str(values["callsign"] + "-" + values["nodeid"])] = layer_4_service.faraday_uart_object(str(values["com"]), int(values["baudrate"]), int(values["timeout"]))
 
         for key in unitDict:
-            logger.info('Starting Thread For Unit: ' + str(key))
+            logger.info('Starting Thread For Unit: {0}'.format(str(key)))
             tempdict = {"unit": key, 'com': unitDict[key]}
             t = threading.Thread(target=uart_worker, args=(tempdict, getDicts, units, log))
             t.start()

--- a/faraday/proxy.py
+++ b/faraday/proxy.py
@@ -90,9 +90,9 @@ def initializeProxyConfig():
     :return: None, exits program
     '''
 
-    logger.info("Initializing Proxy")
+    logger.debug("Initializing Proxy")
     shutil.copy(os.path.join(path, "proxy.sample.ini"), os.path.join(path, "proxy.ini"))
-    logger.info("Initialization complete")
+    logger.debug("Initialization complete")
     sys.exit(0)
 
 
@@ -246,7 +246,7 @@ def uart_worker(modem, getDicts, units, log):
     that checks all Faraday "ports" for data and appends/pops data from
     queues for send and receive directions.
     """
-    logger.info('Starting uart_worker thread')
+    logger.debug('Starting uart_worker thread')
 
     # Iterate through dictionary of each unit in the dictionary creating a
     # deque for each item
@@ -316,7 +316,7 @@ def testdb_read_worker():
     is not present.  The callsign and nodeid are derived from
     the config file.
     """
-    logger.info('Starting testdb_read_worker thread')
+    logger.debug('Starting testdb_read_worker thread')
 
     # Obtain the test callsign and nodeid and create a
     # deque
@@ -567,7 +567,7 @@ def proxy():
                     {'Content-Type': 'application/json'}
             else:
                 # No data in service port, but port is being used
-                logger.info("Empty buffer for port {0}".format(port))
+                logger.debug("Empty buffer for port {0}".format(port))
                 return '', 204  # HTTP 204 response cannot have message data
 
         except ValueError as e:

--- a/faraday/proxy.py
+++ b/faraday/proxy.py
@@ -381,7 +381,6 @@ def testdb_read_worker():
 app = Flask(__name__)
 
 
-
 @app.route('/', methods=['GET', 'POST'])
 def proxy():
     """

--- a/faraday/proxy.py
+++ b/faraday/proxy.py
@@ -459,7 +459,6 @@ def proxy():
                 {"error": "Error: No 'data' key in dictionary"}), 400
         else:
             total = len(data["data"])
-            print "length:", total
             sent = 0
             for item in data['data']:
                 try:

--- a/faraday/proxy.py
+++ b/faraday/proxy.py
@@ -57,6 +57,7 @@ logger.debug('Proxy.ini PATH: ' + proxyConfigPath)
 # Command line input
 parser = argparse.ArgumentParser(description='Proxy application interfaces a Faraday radio over USB UART')
 parser.add_argument('--init-config', dest='init', action='store_true', help='Initialize Proxy configuration file')
+parser.add_argument('--start', action='store_true', help='Start Proxy server')
 parser.add_argument('--callsign', help='Set Faraday callsign')
 parser.add_argument('--nodeid', type=int, help='Set Faraday node ID')
 parser.add_argument('--port', help='Set Faraday UART port')
@@ -78,7 +79,7 @@ parser.add_argument('--schema', help='Set Faraday database schema')
 parser.add_argument('--test-database', dest='testdatabase', help='Set Faraday test mode database')
 parser.add_argument('--init-log', dest='initlog', action='store_true', help='Initialize Proxy log database')
 parser.add_argument('--save-log', dest='savelog', help='Save Proxy log database into new SAVELOG file')
-parser.add_argument('--show-logs', action='store_true', help='Show Proxy log database files')
+parser.add_argument('--show-logs', dest='showlogs', action='store_true', help='Show Proxy log database files')
 
 # Proxy Flask options
 parser.add_argument('--flask-host', dest='flaskhost', help='Set Faraday Flask server host address')
@@ -235,6 +236,11 @@ if args.savelog is not None:
 # List Proxy log database files
 if args.showlogs:
     showProxyLogs()
+
+# Check for --start option and exit if not present
+if not args.start:
+    logger.warning("--start option not present, exiting Proxy server!")
+    sys.exit(0)
 
 # Create and initialize dictionary queues
 postDict = {}

--- a/faraday/simpleconfig.py
+++ b/faraday/simpleconfig.py
@@ -52,9 +52,15 @@ config.read(filename)
 parser = argparse.ArgumentParser(description='SimpleConfig sends a request to faraday-deviceconfiguration to initiate a POST or GET command resulting in programming a Faraday radio and/or reading its FLASH memory configuration')
 
 parser.add_argument('--read', action='store_true', help='Read FLASH configuration only, do not program')
+parser.add_argument('--start', action='store_true', help='Start SimpleConfig script')
 
 # Parse the arguments
 args = parser.parse_args()
+
+# Check for --start option and exit if not present
+if not args.start:
+    logger.warning("--start option not present, exiting SimpleConfig script!")
+    sys.exit(0)
 
 #Variables
 local_device_callsign = config.get("DEVICES", "CALLSIGN")

--- a/faraday/simpleui.py
+++ b/faraday/simpleui.py
@@ -174,7 +174,6 @@ def simpleui():
                                nodeid=nodeid)
 
     if request.method == "POST":
-        # Start the proxy server after configuring the configuration file correctly
         # Setup a Faraday IO object
         faraday_1 = faradaybasicproxyio.proxyio()  # default proxy port
         faraday_cmd = faradaycommands.faraday_commands()

--- a/faraday/simpleui.py
+++ b/faraday/simpleui.py
@@ -55,7 +55,6 @@ simpleuiConfig = ConfigParser.RawConfigParser()
 
 # Command line input
 parser = argparse.ArgumentParser(description='SimpleUI application provides a simple user interface for Faraday radios at http://localhost/')
-parser.add_argument('--start', action='store_true', help='Start SimpleUI in browser')
 parser.add_argument('--init-config', dest='init', action='store_true', help='Initialize SimpleUI configuration file')
 parser.add_argument('--callsign', help='Set Local SimpleUI callsign for data display')
 parser.add_argument('--nodeid', help='Set Local SimpleUI nodeid for data display')
@@ -69,6 +68,7 @@ parser.add_argument('--proxyhost', help='Set Proxy server hostname/address')
 parser.add_argument('--proxyport', help='Set Proxy server port')
 parser.add_argument('--telemetryhost', help='Set Telemetry server hostname/address')
 parser.add_argument('--telemetryport', help='Set Telemetry server port')
+parser.add_argument('--start', action='store_true', help='Start SimpleUI server')
 
 # Parse the arguments
 args = parser.parse_args()
@@ -137,15 +137,18 @@ configureSimpleUI(args, simpleuiConfigPath)
 # Read in configuration file settings
 simpleuiConfig.read(simpleuiConfigPath)
 
-# Start web browser pointed to SimpleUI if requested
-if args.start:
-    host = simpleuiConfig.get("FLASK", "HOST")
-    port = simpleuiConfig.get("FLASK", "PORT")
-    url = "http://" + host + ":" + port
+# Check for --start option and exit if not present
+if not args.start:
+    logger.warning("--start option not present, exiting SimpleUI server!")
+    sys.exit(0)
 
-    logging.debug("SimpleUI URL: " + url)
+host = simpleuiConfig.get("FLASK", "HOST")
+port = simpleuiConfig.get("FLASK", "PORT")
+url = "http://" + host + ":" + port
 
-    webbrowser.open_new(url)
+logging.debug("SimpleUI URL: " + url)
+
+webbrowser.open_new(url)
 
 
 # Initialize Flask microframework

--- a/faraday/telemetry.py
+++ b/faraday/telemetry.py
@@ -45,7 +45,7 @@ for location in os.curdir, relpath1, relpath2, setuppath, userpath:
 
 logger = logging.getLogger('Telemetry')
 
-# Create Proxy configuration file path
+# Create Telemery configuration file path
 telemetryConfigPath = os.path.join(path, "telemetry.ini")
 logger.debug('telemetry.ini PATH: ' + telemetryConfigPath)
 
@@ -69,7 +69,7 @@ parser.add_argument('--init-log', dest='initlog', action='store_true', help='Ini
 parser.add_argument('--save-log', dest='savelog', help='Save Telemetry log database into new SAVELOG file')
 parser.add_argument('--show-logs', dest='showlogs', action='store_true', help='Show Telemetry log database files')
 
-# Proxy Flask options
+# Telemetry Flask options
 parser.add_argument('--flask-host', dest='flaskhost', help='Set Faraday Telemetry Flask server host address')
 parser.add_argument('--flask-port', type=int, dest='flaskport', help='Set Faraday Telemetry Flask server port')
 
@@ -98,7 +98,7 @@ def initializeTelemetryLog(config):
     :return: None
     '''
 
-    logger.info("Initializing Proxy Log File")
+    logger.info("Initializing Telemetry Log File")
     log = config.get("DATABASE", "filename")
     logpath = os.path.join(os.path.expanduser('~'), '.faraday', 'lib', log)
     os.remove(logpath)
@@ -169,7 +169,7 @@ def configureTelemetry(args, telemetryConfigPath):
     if args.schema is not None:
         config.set('DATABASE', 'schemaname', args.schema)
 
-    # Configure Proxy flask server
+    # Configure Telemetry flask server
     if args.flaskhost is not None:
         config.set('FLASK', 'host', args.flaskhost)
     if args.flaskport is not None:

--- a/faraday/telemetry.py
+++ b/faraday/telemetry.py
@@ -61,6 +61,7 @@ parser.add_argument('--init-config', dest='init', action='store_true', help='Ini
 parser.add_argument('--callsign', help='Set Faraday callsign in Proxy to connect to')
 parser.add_argument('--nodeid', type=int, help='Set Faraday node ID in Proxy to connect to')
 parser.add_argument('--unit', type=int, default=0, help='Specify Faraday unit to configure')
+parser.add_argument('--start', action='store_true', help='Start Telemetry server')
 
 # Telemetry database options
 parser.add_argument('--database', help='Set Telemetry database name')
@@ -199,6 +200,11 @@ if args.savelog is not None:
 # List Telemetry log database files
 if args.showlogs:
     showTelemetryLogs()
+
+# Check for --start option and exit if not present
+if not args.start:
+    logger.warning("--start option not present, exiting Telemetry server!")
+    sys.exit(0)
 
 
 if len(telemetryFile) == 0:


### PR DESCRIPTION
Per issues #228, #229, #230, #231, #232, and #233 I've implemented/updated the `--start` option for all applications. This means that `faraday-proxy`, `faraday-telemetry`, `faraday-aprs`, `faraday-simpleui`, `faraday-deviceconfiguration`, and `faraday-simpleconfig` now all require a `--start` option. 

NOTE: This will require update to the quickstart documentation to use the `--start` option before pulling in this PR

Attention to this awesomeness: @reillyeon @el-iso