### PR TITLE
Fix Proxy Configuration Exceptions

### DIFF
--- a/faraday/proxy.py
+++ b/faraday/proxy.py
@@ -213,7 +213,16 @@ def configureProxy(args, proxyConfigPath):
 # Initialize and configure proxy
 if args.init:
     initializeProxyConfig()
-configureProxy(args, proxyConfigPath)
+
+# Attempt to configure proxy
+try:
+    configureProxy(args, proxyConfigPath)
+
+except ConfigParser.NoSectionError as e:
+    # Possible that no configuration file found
+    logger.error('Proxy configuration file error!')
+    logger.error(e)
+    sys.exit(0)
 
 # Load Proxy Configuration from proxy.ini file
 proxyConfig = ConfigParser.RawConfigParser()

--- a/faraday/proxy.py
+++ b/faraday/proxy.py
@@ -223,7 +223,7 @@ except ConfigParser.NoSectionError as e:
     logger.error('Proxy configuration file error!')
     logger.error('Did you rememebr to --init-config?')
     logger.error(e)
-    sys.exit(0)
+    sys.exit(1)
 
 # Load Proxy Configuration from proxy.ini file
 proxyConfig = ConfigParser.RawConfigParser()

--- a/faraday/proxy.py
+++ b/faraday/proxy.py
@@ -221,6 +221,7 @@ try:
 except ConfigParser.NoSectionError as e:
     # Possible that no configuration file found
     logger.error('Proxy configuration file error!')
+    logger.error('Did you rememebr to --init-config?')
     logger.error(e)
     sys.exit(0)
 

--- a/faraday/proxy.py
+++ b/faraday/proxy.py
@@ -227,7 +227,7 @@ try:
 except ConfigParser.NoSectionError as e:
     # Possible that no configuration file found
     logger.error('Proxy configuration file error!')
-    logger.error('Did you rememebr to --init-config?')
+    logger.error('Did you remember to --init-config?')
     logger.error(e)
     sys.exit(1)
 

--- a/faraday/uart/layer_4_service.py
+++ b/faraday/uart/layer_4_service.py
@@ -204,7 +204,7 @@ class faraday_uart_object(threading.Thread):
             pass
 
     def Abort(self):
-        logger.error("Abording layer 4 faraday_uart_object")
+        logger.error("Aborting layer 4 faraday_uart_object")
         self.layer_2_object.Abort()  #Abort lower layers
         self.enabled = False
 


### PR DESCRIPTION
Per #208 this PR now catches exceptions when:
- `--init-config` has not been run and no proxy.ini exists

Since this PR is based on PR #195 (so please pull that in first or else this includes all of #195 as well...) it also catches UARTstack exceptions when the UART port is mis-configured. Overall this is a quick fix to a pesky issue that makes Proxy a bit cleaner to use.

@el-iso  @reillyeon @kb1lqd 