### PR TITLE
Aprs telem

### DIFF
--- a/faraday/aprs.py
+++ b/faraday/aprs.py
@@ -17,6 +17,7 @@ import os
 from time import sleep
 import sys
 import argparse
+from aprslib import base91
 
 from classes import helper
 
@@ -273,8 +274,16 @@ def sendPositions(stations, socket):
         node = sourceCallsign + "-" + str(sourceID)
         destNode = destinationCallsign + "-" + str(destinationID)
 
+        # Generate BASE91 telemetry
+        b91a = base91.from_decimal(station["ADC0"])
+        logger.info("ADC0 - {0}".format(b91a))
+
         # Convert position to APRS-IS compliant string
         latString, lonString = nmeaToDegDecMin(latitude, longitude)
+
+        #dev
+        latString = '3359.00'
+        lonString = '11825.00'
 
         # Convert altitude and speed to APRS compliant values
         try:
@@ -416,11 +425,11 @@ def sendtelemetry(stations, telemSequence, socket):
                 node,
                 destAddress,
                 str(telemSequence).zfill(3),
-                str(station["ADC0"] / 16).zfill(3),
-                str(station["ADC1"] / 16).zfill(3),
-                str(station["ADC3"] / 16).zfill(3),
-                str(station["ADC6"] / 16).zfill(3),
-                str(station["BOARDTEMP"] / 16).zfill(3),
+                str(4095),
+                str(4095),
+                str(4095),
+                str(4095),
+                str(4095),
                 ioList)
 
             logger.debug(telemetry)

--- a/faraday/aprs.py
+++ b/faraday/aprs.py
@@ -276,35 +276,22 @@ def sendPositions(telemSequence, stations, socket):
         node = sourceCallsign + "-" + str(sourceID)
         destNode = destinationCallsign + "-" + str(destinationID)
 
-        # Generate BASE91 telemetry
-        # station["ADC0"] = 1472
-        # station["ADC1"] = 1564
-        # station["ADC3"] = 1656
-        # station["ADC6"] = 1748
-        # station["BOARDTEMP"] = 1840
+        # Generate BASE91 telemetry with aprslib using a width of 2
         b91seq = base91.from_decimal(telemSequence, 2)
         b91a = base91.from_decimal(station["ADC0"], 2)
         b91b = base91.from_decimal(station["ADC1"], 2)
         b91c = base91.from_decimal(station["ADC3"], 2)
         b91d = base91.from_decimal(station["ADC6"], 2)
         b91e = base91.from_decimal(station["BOARDTEMP"], 2)
-        logger.info("sequence - {0}".format(b91seq))
-        logger.info("ADC0 - {0}".format(b91a))
-        logger.info("ADC1 - {0}".format(b91b))
-        logger.info("ADC3 - {0}".format(b91c))
-        logger.info("ADC6 - {0}".format(b91d))
-        logger.info("BOARDTEMP - {0}".format(b91e))
 
-        altComment = "|{0}{1}{2}{3}{4}{5}|".format(b91seq,b91a,b91b,b91c,b91d,b91e)
-        #altComment = "|{0}{1}{2}|".format(b91seq,b91a,b91b)
-        logger.info(altComment)
+        b91Tlm = "|{0}{1}{2}{3}{4}{5}|".format(b91seq,b91a,b91b,b91c,b91d,b91e)
+
+        # add telemetry to comments
+        comment = comment + b91Tlm
+        altComment = altComment + b91Tlm
 
         # Convert position to APRS-IS compliant string
         latString, lonString = nmeaToDegDecMin(latitude, longitude)
-
-        #dev
-        latString = '3359.00'
-        lonString = '11825.00'
 
         # Convert altitude and speed to APRS compliant values
         try:
@@ -335,23 +322,14 @@ def sendPositions(telemSequence, stations, socket):
                     longitudeDir,
                     symbol])
 
-                # positionString = '{}>{},{},{}:{}.../{}/A={}{}\r'.format(
-                #     node,
-                #     destAddress,
-                #     qConstruct,
-                #     destNode,
-                #     aprsPosition,
-                #     speed,
-                #     altitude,
-                #     comment)
-
-                positionString = '{}>{},{},{}:{}.../{}/{}\r'.format(
+                positionString = '{}>{},{},{}:{}.../{}/A={}{}\r'.format(
                     node,
                     destAddress,
                     qConstruct,
                     destNode,
                     aprsPosition,
                     speed,
+                    altitude,
                     comment)
 
                 logger.debug(positionString)

--- a/faraday/aprs.py
+++ b/faraday/aprs.py
@@ -297,7 +297,7 @@ def sendPositions(telemSequence, stations, socket):
         b91e = base91.from_decimal(station["BOARDTEMP"], 2)
         b91f = base91.from_decimal(ioList, 2)
 
-        b91Tlm = "|{0}{1}{2}{3}{4}{5}{6}|".format(b91seq,b91a,b91b,b91c,b91d,b91e,b91f)
+        b91Tlm = "|{0}{1}{2}{3}{4}{5}{6}|".format(b91seq, b91a, b91b, b91c, b91d, b91e, b91f)
 
         # add telemetry to comments
         comment = comment + b91Tlm

--- a/faraday/aprs.py
+++ b/faraday/aprs.py
@@ -282,12 +282,12 @@ def sendPositions(telemSequence, stations, socket):
         # station["ADC3"] = 1656
         # station["ADC6"] = 1748
         # station["BOARDTEMP"] = 1840
-        b91seq = base91.from_decimal(telemSequence).rjust(2,"!")
-        b91a = base91.from_decimal(station["ADC0"]).rjust(2,"!")
-        b91b = base91.from_decimal(station["ADC1"]).rjust(2,"!")
-        b91c = base91.from_decimal(station["ADC3"]).rjust(2,"!")
-        b91d = base91.from_decimal(station["ADC6"]).rjust(2,"!")
-        b91e = base91.from_decimal(station["BOARDTEMP"]).rjust(2,"!")
+        b91seq = base91.from_decimal(telemSequence, 2)
+        b91a = base91.from_decimal(station["ADC0"], 2)
+        b91b = base91.from_decimal(station["ADC1"], 2)
+        b91c = base91.from_decimal(station["ADC3"], 2)
+        b91d = base91.from_decimal(station["ADC6"], 2)
+        b91e = base91.from_decimal(station["BOARDTEMP"], 2)
         logger.info("sequence - {0}".format(b91seq))
         logger.info("ADC0 - {0}".format(b91a))
         logger.info("ADC1 - {0}".format(b91b))

--- a/faraday/aprs.py
+++ b/faraday/aprs.py
@@ -448,11 +448,11 @@ def sendtelemetry(stations, telemSequence, socket):
                 node,
                 destAddress,
                 str(telemSequence).zfill(3),
-                str(4095),
-                str(4095),
-                str(4095),
-                str(4095),
-                str(4095),
+                str(station["ADC0"] / 16).zfill(3),
+                str(station["ADC1"] / 16).zfill(3),
+                str(station["ADC3"] / 16).zfill(3),
+                str(station["ADC6"] / 16).zfill(3),
+                str(station["BOARDTEMP"] / 16).zfill(3),
                 ioList)
 
             logger.debug(telemetry)

--- a/faraday/aprs.py
+++ b/faraday/aprs.py
@@ -115,13 +115,14 @@ def aprs_worker(config, sock):
         logger.info(str.format(len(stations)))
 
         # Iterate through all stations sending telemetry and position data
-        # TODO update sequencer with 0x1FFF wrapper per BASE91 APRS spec
         sendPositions(telemSequence, stationData, sock)
+
+        # Just send labels, Parameters, and Equations during first sequence
+        if telemSequence == 0:
+            sendTelemLabels(stationData, sock)
+            sendParameters(stationData, sock)
+            sendEquations(stationData, sock)
         telemSequence += 1
-        #telemSequence = sendtelemetry(stationData, telemSequence, sock)
-        sendTelemLabels(stationData, sock)
-        sendParameters(stationData, sock)
-        sendEquations(stationData, sock)
 
         # Sleep for intended update rate (seconds)
         sleep(rate)

--- a/faraday/aprs.py
+++ b/faraday/aprs.py
@@ -271,10 +271,21 @@ def sendPositions(telemSequence, stations, socket):
         altSymbol = aprsConfig.get('APRS', 'ALTSYMBOL')
         comment = aprsConfig.get('APRS', 'COMMENT')
         altComment = aprsConfig.get('APRS', 'ALTCOMMENT')
+        ioSource = aprsConfig.get('APRS', 'IOSOURCE').upper()
 
         # Create nodes from GPS data
         node = sourceCallsign + "-" + str(sourceID)
         destNode = destinationCallsign + "-" + str(destinationID)
+
+        #Obtain GPIO data
+        gpioValues = station["GPIOSTATE"]
+        rfValues = station["RFSTATE"]
+
+        # Extract IO data
+        if ioSource == 'GPIO':
+            ioList = gpioValues
+        elif ioSource == 'RF':
+            ioList = rfValues
 
         # Generate BASE91 telemetry with aprslib using a width of 2
         b91seq = base91.from_decimal(telemSequence, 2)
@@ -283,8 +294,9 @@ def sendPositions(telemSequence, stations, socket):
         b91c = base91.from_decimal(station["ADC3"], 2)
         b91d = base91.from_decimal(station["ADC6"], 2)
         b91e = base91.from_decimal(station["BOARDTEMP"], 2)
+        b91f = base91.from_decimal(ioList, 2)
 
-        b91Tlm = "|{0}{1}{2}{3}{4}{5}|".format(b91seq,b91a,b91b,b91c,b91d,b91e)
+        b91Tlm = "|{0}{1}{2}{3}{4}{5}{6}|".format(b91seq,b91a,b91b,b91c,b91d,b91e,b91f)
 
         # add telemetry to comments
         comment = comment + b91Tlm

--- a/faraday/aprs.py
+++ b/faraday/aprs.py
@@ -276,7 +276,15 @@ def sendPositions(stations, socket):
 
         # Generate BASE91 telemetry
         b91a = base91.from_decimal(station["ADC0"])
+        b91b = base91.from_decimal(station["ADC1"])
+        b91c = base91.from_decimal(station["ADC3"])
+        b91d = base91.from_decimal(station["ADC6"])
+        b91e = base91.from_decimal(station["BOARDTEMP"])
         logger.info("ADC0 - {0}".format(b91a))
+        logger.info("ADC1 - {0}".format(b91b))
+        logger.info("ADC3 - {0}".format(b91c))
+        logger.info("ADC6 - {0}".format(b91d))
+        logger.info("BOARDTEMP - {0}".format(b91e))
 
         # Convert position to APRS-IS compliant string
         latString, lonString = nmeaToDegDecMin(latitude, longitude)

--- a/faraday/aprs.py
+++ b/faraday/aprs.py
@@ -117,6 +117,7 @@ def aprs_worker(config, sock):
         # Iterate through all stations sending telemetry and position data
         # TODO update sequencer with 0x1FFF wrapper per BASE91 APRS spec
         sendPositions(telemSequence, stationData, sock)
+        telemSequence += 1
         #telemSequence = sendtelemetry(stationData, telemSequence, sock)
         sendTelemLabels(stationData, sock)
         sendParameters(stationData, sock)
@@ -276,18 +277,27 @@ def sendPositions(telemSequence, stations, socket):
         destNode = destinationCallsign + "-" + str(destinationID)
 
         # Generate BASE91 telemetry
-        b91seq = base91.from_decimal(telemSequence)
-        b91a = base91.from_decimal(station["ADC0"])
-        b91b = base91.from_decimal(station["ADC1"])
-        b91c = base91.from_decimal(station["ADC3"])
-        b91d = base91.from_decimal(station["ADC6"])
-        b91e = base91.from_decimal(station["BOARDTEMP"])
+        # station["ADC0"] = 1472
+        # station["ADC1"] = 1564
+        # station["ADC3"] = 1656
+        # station["ADC6"] = 1748
+        # station["BOARDTEMP"] = 1840
+        b91seq = base91.from_decimal(telemSequence).rjust(2,"!")
+        b91a = base91.from_decimal(station["ADC0"]).rjust(2,"!")
+        b91b = base91.from_decimal(station["ADC1"]).rjust(2,"!")
+        b91c = base91.from_decimal(station["ADC3"]).rjust(2,"!")
+        b91d = base91.from_decimal(station["ADC6"]).rjust(2,"!")
+        b91e = base91.from_decimal(station["BOARDTEMP"]).rjust(2,"!")
         logger.info("sequence - {0}".format(b91seq))
         logger.info("ADC0 - {0}".format(b91a))
         logger.info("ADC1 - {0}".format(b91b))
         logger.info("ADC3 - {0}".format(b91c))
         logger.info("ADC6 - {0}".format(b91d))
         logger.info("BOARDTEMP - {0}".format(b91e))
+
+        altComment = "|{0}{1}{2}{3}{4}{5}|".format(b91seq,b91a,b91b,b91c,b91d,b91e)
+        #altComment = "|{0}{1}{2}|".format(b91seq,b91a,b91b)
+        logger.info(altComment)
 
         # Convert position to APRS-IS compliant string
         latString, lonString = nmeaToDegDecMin(latitude, longitude)
@@ -325,14 +335,23 @@ def sendPositions(telemSequence, stations, socket):
                     longitudeDir,
                     symbol])
 
-                positionString = '{}>{},{},{}:{}.../{}/A={}{}\r'.format(
+                # positionString = '{}>{},{},{}:{}.../{}/A={}{}\r'.format(
+                #     node,
+                #     destAddress,
+                #     qConstruct,
+                #     destNode,
+                #     aprsPosition,
+                #     speed,
+                #     altitude,
+                #     comment)
+
+                positionString = '{}>{},{},{}:{}.../{}/{}\r'.format(
                     node,
                     destAddress,
                     qConstruct,
                     destNode,
                     aprsPosition,
                     speed,
-                    altitude,
                     comment)
 
                 logger.debug(positionString)

--- a/faraday/aprs.py
+++ b/faraday/aprs.py
@@ -237,8 +237,10 @@ def nmeaToDegDecMin(latitude, longitude):
 
 def sendPositions(telemSequence, stations, socket):
     """
-    Constructs an APRS position string for station and sends to a socket
+    Constructs an APRS position string for station and sends to a socket.
+    Includes BASE91 comment telemetry functionality as well.
 
+    :param telemSequence: Telemetry sequence number
     :param stations: List of dictionary organized station data
     :param socket: APRS-IS server internet socket
     :return: None

--- a/faraday/aprs.py
+++ b/faraday/aprs.py
@@ -115,8 +115,9 @@ def aprs_worker(config, sock):
         logger.info(str.format(len(stations)))
 
         # Iterate through all stations sending telemetry and position data
-        sendPositions(stationData, sock)
-        telemSequence = sendtelemetry(stationData, telemSequence, sock)
+        # TODO update sequencer with 0x1FFF wrapper per BASE91 APRS spec
+        sendPositions(telemSequence, stationData, sock)
+        #telemSequence = sendtelemetry(stationData, telemSequence, sock)
         sendTelemLabels(stationData, sock)
         sendParameters(stationData, sock)
         sendEquations(stationData, sock)
@@ -232,7 +233,7 @@ def nmeaToDegDecMin(latitude, longitude):
     return [latString, lonString]
 
 
-def sendPositions(stations, socket):
+def sendPositions(telemSequence, stations, socket):
     """
     Constructs an APRS position string for station and sends to a socket
 
@@ -275,11 +276,13 @@ def sendPositions(stations, socket):
         destNode = destinationCallsign + "-" + str(destinationID)
 
         # Generate BASE91 telemetry
+        b91seq = base91.from_decimal(telemSequence)
         b91a = base91.from_decimal(station["ADC0"])
         b91b = base91.from_decimal(station["ADC1"])
         b91c = base91.from_decimal(station["ADC3"])
         b91d = base91.from_decimal(station["ADC6"])
         b91e = base91.from_decimal(station["BOARDTEMP"])
+        logger.info("sequence - {0}".format(b91seq))
         logger.info("ADC0 - {0}".format(b91a))
         logger.info("ADC1 - {0}".format(b91b))
         logger.info("ADC3 - {0}".format(b91c))


### PR DESCRIPTION
# Changelog
- Imports aprslib and uses base91 functionality. Please note that this is note a standard BASE91 implementation and is a custom APRS version of base91. Qeue [XKCD](https://xkcd.com/927/).
- Removes use of `sendTelemetry` function as it is no longer needed
- Only sends scaling values on first transmission to reduce unnecessary packet transmissions. This should be revisited later but seems good for now.
- Sends a `telemetrySequence` number that is unbounded to `sendPosition` as BASE91 comment telemetry can support up to 16 bits of counting and this should be fine for the forceable future :)
- `sendPosition` implements [BASE91 Comment Telemetry](http://he.fi/doc/aprs-base91-comment-telemetry.txt) with ADC0, ADC1, ADC3, ADC6, BOARDTEMP, and GPIO bits per #266.

Raw packets which end in BASE91 comment telemetry 
![image](https://user-images.githubusercontent.com/331540/30197057-2b826f0a-941a-11e7-95a8-b29ba9a6155e.png)

12 bit ADC data looks very nice!
![image](https://user-images.githubusercontent.com/331540/30197084-65efa518-941a-11e7-9e7a-331c38e1ad4e.png)
