### PR TITLE
Fix Faraday-Telemetry For Use on Raspberry Pi

### DIFF
--- a/faraday/aprs.py
+++ b/faraday/aprs.py
@@ -166,7 +166,14 @@ def getStations():
     logger.debug(url)
 
     r = requests.get(url)
-    results = r.json()
+
+    try:
+        results = r.json()
+
+    except ValueError as e:
+        # JSON ValueError error, just return a blank value
+        logger.error(e)
+        results = ''
 
     # Return extracted JSON data
     return results

--- a/faraday/aprs.py
+++ b/faraday/aprs.py
@@ -102,37 +102,37 @@ def aprs_worker(config):
     rate = config.getint("APRSIS", "RATE")
 
     # Local variable initialization
-    telemSequence = 0
     conn = False
 
     # Start infinite loop to send station data to APRS-IS
     while True:
-        # Query telemetry database for station data
-        stations = getStations()
-        stationData = getStationData(stations)
+        # Count through 8280 telemetry sequences (BASE91 limit)
+        for sequence in range(8280):
+            # Query telemetry database for station data
+            stations = getStations()
+            stationData = getStationData(stations)
 
-        # Indicate number of stations tracking
-        str = "Tracking {0} Faraday stations..."
-        logger.info(str.format(len(stations)))
+            # Indicate number of stations tracking
+            str = "Tracking {0} Faraday stations..."
+            logger.info(str.format(len(stations)))
 
-        # Iterate through all stations sending telemetry and position data
-        if not conn:
-            sock = connectAPRSIS()
-        try:
-            conn = sendPositions(telemSequence, stationData, sock)
+            # Iterate through all stations sending telemetry and position data
+            if not conn:
+                sock = connectAPRSIS()
+            try:
+                conn = sendPositions(sequence, stationData, sock)
 
-            # Just send labels, Parameters, and Equations every 10th loop
-            if telemSequence % 10 == 0:
-                sendTelemLabels(stationData, sock)
-                sendParameters(stationData, sock)
-                sendEquations(stationData, sock)
-            telemSequence += 1
+                # Just send labels, Parameters, and Equations every 10th loop
+                if sequence % 10 == 0:
+                    sendTelemLabels(stationData, sock)
+                    sendParameters(stationData, sock)
+                    sendEquations(stationData, sock)
 
-        except StandardError as e:
-            logger.error(e)
+            except StandardError as e:
+                logger.error(e)
 
-        # Sleep for intended update rate (seconds)
-        sleep(rate)
+            # Sleep for intended update rate (seconds)
+            sleep(rate)
 
 
 # Now act upon the command line arguments

--- a/faraday/telemetry.py
+++ b/faraday/telemetry.py
@@ -981,7 +981,7 @@ def queryStationsDb(parameters):
         logger.error(paramTuple)
         return sqlData
 
-    conn.row_factory = sqlite3.Row  # SQLite.Row returns columns,values
+    queryStationsDB.row_factory = sqlite3.Row  # SQLite.Row returns columns,values
     cur = queryStationsDB.cursor()
 
     try:

--- a/faraday/telemetry.py
+++ b/faraday/telemetry.py
@@ -76,12 +76,14 @@ def openDB():
         dbPath = os.path.join(faradayHelper.userPath, 'lib', dbFilename)
         dbFilename = os.path.join(dbPath)
 
+
     except ConfigParser.Error as e:
         logger.error("ConfigParse.Error: " + str(e))
         return False
 
     # Connect to database, enter WAL mode, commit SQL
     try:
+
         conn = sqlite3.connect(dbFilename)
         conn.execute("PRAGMA journal_mode=WAL;")
         conn.commit()
@@ -330,8 +332,14 @@ def telemetry_worker(config):
 
                     else:
                         workerDB = openDB()
-                        sqlInsert(workerDB, parsedTelemetry)
-                        telemetryDicts[str(callsign) + str(nodeid)].append(parsedTelemetry)
+                        logger.info(workerDB)
+                        if workerDB:
+                            sqlInsert(workerDB, parsedTelemetry)
+                            telemetryDicts[str(callsign) + str(nodeid)].append(parsedTelemetry)
+                        else:
+                            # An error has occured writing to database, break
+                            logger.error("Telemetry worker database error")
+                            break
         time.sleep(1)  # Slow down main while loop
 
 

--- a/faraday/telemetry.py
+++ b/faraday/telemetry.py
@@ -65,18 +65,22 @@ parser.add_argument('--flask-port', type=int, dest='flaskport', help='Set Farada
 args = parser.parse_args()
 
 def openDB():
-    # Read in name of database
+    '''
+    Open telemetry database and return a SQLite3 connection
+
+    :return: SQLite connection
+    '''
+    # Read in name of database from configuration file
     try:
         dbFilename = telemetryConfig.get("DATABASE", "FILENAME")
         dbPath = os.path.join(faradayHelper.userPath, 'lib', dbFilename)
-        logger.debug("Telemetry Database: " + dbPath)
         dbFilename = os.path.join(dbPath)
 
     except ConfigParser.Error as e:
         logger.error("ConfigParse.Error: " + str(e))
         return False
 
-    # Connect to database, create SQL query, execute query, and close database
+    # Connect to database, enter WAL mode, commit SQL
     try:
         conn = sqlite3.connect(dbFilename)
         conn.execute("PRAGMA journal_mode=WAL;")
@@ -85,7 +89,9 @@ def openDB():
     except sqlite3.Error as e:
         logger.error("Sqlite3.error: " + str(e))
         conn.close()
+        return False
 
+    # Return SQLite3 connection
     return conn
 
 

--- a/faraday/telemetry.py
+++ b/faraday/telemetry.py
@@ -64,6 +64,7 @@ parser.add_argument('--flask-port', type=int, dest='flaskport', help='Set Farada
 # Parse the arguments
 args = parser.parse_args()
 
+
 def openDB():
     '''
     Open telemetry database and return a SQLite3 connection
@@ -75,7 +76,6 @@ def openDB():
         dbFilename = telemetryConfig.get("DATABASE", "FILENAME")
         dbPath = os.path.join(faradayHelper.userPath, 'lib', dbFilename)
         dbFilename = os.path.join(dbPath)
-
 
     except ConfigParser.Error as e:
         logger.error("ConfigParse.Error: " + str(e))

--- a/faraday/telemetry.py
+++ b/faraday/telemetry.py
@@ -258,10 +258,6 @@ def telemetry_worker(config):
     # Initialize Faraday parser
     faradayParser = telemetryparser.TelemetryParse()  # Add logger?
 
-    # open database
-    workerDB = openDB()
-    logger.info("TelemetryDB = {0}".format(workerDB))
-
     try:
         # Pragmatically create descriptors for each Faraday connected to Proxy
         count = config.getint("TELEMETRY", "UNITS")
@@ -325,6 +321,7 @@ def telemetry_worker(config):
                         logger.error("KeyError: " + str(e))
 
                     else:
+                        workerDB = openDB()
                         sqlInsert(workerDB, parsedTelemetry)
                         telemetryDicts[str(callsign) + str(nodeid)].append(parsedTelemetry)
         time.sleep(1)  # Slow down main while loop
@@ -778,11 +775,11 @@ def sqlInsert(dbConn, data):
         except sqlite3.Error as e:
             logger.error("Sqlite3.Error: " + str(e))
             dbConn.rollback()
-            #dbConn.close()
+            dbConn.close()
             return False
 
         # Completed, close database and return True
-        #dbCconn.close()
+        dbConn.close()
         return True
 
     else:

--- a/faraday/telemetry.py
+++ b/faraday/telemetry.py
@@ -79,7 +79,6 @@ def openDB():
 
     except ConfigParser.Error as e:
         logger.error("ConfigParse.Error: " + str(e))
-        return False
 
     # Connect to database, enter WAL mode, commit SQL
     try:
@@ -91,7 +90,6 @@ def openDB():
     except sqlite3.Error as e:
         logger.error("Sqlite3.error: " + str(e))
         conn.close()
-        return False
 
     # Return SQLite3 connection
     return conn
@@ -332,14 +330,8 @@ def telemetry_worker(config):
 
                     else:
                         workerDB = openDB()
-                        logger.info(workerDB)
-                        if workerDB:
-                            sqlInsert(workerDB, parsedTelemetry)
-                            telemetryDicts[str(callsign) + str(nodeid)].append(parsedTelemetry)
-                        else:
-                            # An error has occured writing to database, break
-                            logger.error("Telemetry worker database error")
-                            break
+                        sqlInsert(workerDB, parsedTelemetry)
+                        telemetryDicts[str(callsign) + str(nodeid)].append(parsedTelemetry)
         time.sleep(1)  # Slow down main while loop
 
 
@@ -668,7 +660,7 @@ def initDB():
         # after connecting. Close the database when complete.
         try:
             with open(dbSchema, 'rt') as f:
-                #conn = sqlite3.connect(dbFilename)
+                # Open connection to database, create table and WAL mode, close
                 initConn = openDB()
                 cur = initConn.cursor()
                 schema = f.read()
@@ -867,18 +859,7 @@ def queryDb(parameters):
     sql = sqlBeg + sqlWhereCall + sqlWhereID + sqlEpoch + sqlEnd
     logger.debug(sql)
 
-    # Read in name of database
-    # try:
-    #     dbFilename = telemetryConfig.get("DATABASE", "FILENAME")
-    #     dbPath = os.path.join(faradayHelper.userPath, 'lib', dbFilename)
-    #     logger.debug("Telemetry Database: " + dbPath)
-    #     dbFilename = os.path.join(dbPath)
-    #
-    # except ConfigParser.Error as e:
-    #     logger.error("ConfigParse.Error: " + str(e))
-    #     return False
-
-    # Connect to database, create SQL query, execute query, and close database
+    # Connect to database, execute query, and close database
     try:
         #conn = sqlite3.connect(dbFilename)
         queryConn = openDB()

--- a/faraday/telemetry.py
+++ b/faraday/telemetry.py
@@ -329,6 +329,7 @@ def telemetry_worker(config):
                         logger.error("KeyError: " + str(e))
 
                     else:
+                        # Successful decode, open database and save telemetry
                         workerDB = openDB()
                         sqlInsert(workerDB, parsedTelemetry)
                         telemetryDicts[str(callsign) + str(nodeid)].append(parsedTelemetry)
@@ -744,18 +745,6 @@ def sqlInsert(dbConn, data):
     :param data: Telemetry dictionary
     :return: Status True or False on SQL insertion success
     """
-
-    # Read in name of database
-    # try:
-    #     dbFilename = telemetryConfig.get("DATABASE", "FILENAME")
-    #     dbPath = os.path.join(faradayHelper.userPath, 'lib', dbFilename)
-    #     logger.debug("Telemetry Database: " + dbPath)
-    #     db = os.path.join(dbPath)
-    #
-    # except ConfigParser.Error as e:
-    #     logger.error("ConfigParse.Error: " + str(e))
-    #     return False
-
     # Change dictionary into list with proper order
     telem = createTelemetryList(data)
 
@@ -767,22 +756,14 @@ def sqlInsert(dbConn, data):
         paramSubs = ",".join(paramSubs)
         sql = "INSERT INTO TELEMETRY VALUES(" + paramSubs + ")"
 
-        # Connect to database, create SQL query, execute query, and close database
-        # try:
-        #     conn = sqlite3.connect(db)
-        #
-        # except sqlite3.Error as e:
-        #     logger.error("Sqlite3.Error: " + str(e))
-        #     return False
-
-        # Connect to database, create SQL query, execute query, and close database
+        # Connect to database, execute query, and close database
         try:
-            #conn = sqlite3.connect(db)
-            # Use connection as context manager to rollback automatically if error
+            # Execute SQL
             with dbConn:
                 dbConn.execute(sql, telem)
 
         except sqlite3.Error as e:
+            # An error occured, rollback and close connection, return False
             logger.error("Sqlite3.Error: " + str(e))
             dbConn.rollback()
             dbConn.close()
@@ -861,7 +842,6 @@ def queryDb(parameters):
 
     # Connect to database, execute query, and close database
     try:
-        #conn = sqlite3.connect(dbFilename)
         queryConn = openDB()
 
     except sqlite3.Error as e:
@@ -967,9 +947,8 @@ def queryStationsDb(parameters):
         logger.error("ConfigParse.Error: " + str(e))
         return False
 
-    # Connect to database, create SQL query, execute query, and close database
+    # Connect to database, execute query, and close database
     try:
-        #conn = sqlite3.connect(dbFilename)
         queryStationsDB = openDB()
 
     except sqlite3.Error as e:

--- a/faraday/telemetry.py
+++ b/faraday/telemetry.py
@@ -79,6 +79,8 @@ def openDB():
     # Connect to database, create SQL query, execute query, and close database
     try:
         conn = sqlite3.connect(dbFilename)
+        conn.execute("PRAGMA journal_mode=WAL;")
+        conn.commit()
 
     except sqlite3.Error as e:
         logger.error("Sqlite3.error: " + str(e))
@@ -657,6 +659,8 @@ def initDB():
                 cur = initConn.cursor()
                 schema = f.read()
                 cur.executescript(schema)
+                cur.execute("PRAGMA journal_mode=WAL;")
+                initConn.commit()
             initConn.close()
 
         except sqlite3.Error as e:

--- a/faraday/telemetry.py
+++ b/faraday/telemetry.py
@@ -957,9 +957,9 @@ def queryStationsDb(parameters):
         return sqlData
 
     queryStationsDB.row_factory = sqlite3.Row  # SQLite.Row returns columns,values
-    cur = queryStationsDB.cursor()
 
     try:
+        cur = queryStationsDB.cursor()
         cur.execute(sql, paramTuple)
 
     except sqlite3.Error as e:

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,3 +20,4 @@ pytest-flake8==0.8.1
 requests==2.12.5
 six==1.10.0
 Werkzeug==0.11.15
+aprslib>=0.6.46


### PR DESCRIPTION
Per Faraday-Software #272 and #270 the `faraday-telemetry` software did not run on the Raspberry Pi 3. @reillyeon suggested ensuring each thread had it's own database connection which this PR should do. Also, I found that that alone did not work and enabled [SQLite3 Write-Ahead Logging](https://www.sqlite.org/wal.html) (WAL) mode was also required. This prevented slower operations such as opening/closing the .journal file which is not usually an issue but slow enough on the Raspberry Pi to cause database access issues.

# Changelog
- Created `openDB()` function to help open up database connection easier
- Distributed individual database connections to each thread/function with `openDB()`
- Enabled WAL mode with a PRAGMA SQL query when opening up any database connection
- Cleaned up comments and error handling a tad

# Testing
Currently the code is running on a Raspberry Pi 3 with September 2017 Raspbian. It is updating [KB1LQC-1 on aprs.fi](https://aprs.fi/telemetry/KB1LQC-1) with telemetry data in a duration test at the time of this PR submission.

![image](https://user-images.githubusercontent.com/331540/30468784-fafdb8d4-99a1-11e7-956e-4affe8332770.png)

Also here's a screenshot of the aprs.fi raw telemetry being sent with this branch `faraday-telemetry` code.
![image](https://user-images.githubusercontent.com/331540/30468807-17eea516-99a2-11e7-944f-88ea76877502.png)
