### PR TITLE
Added E722 to flake8 ignore list per travis CI

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [tool:pytest]
 addopts = --flake8
-flake8-ignore = E262 E265 E266 E402 E501
+flake8-ignore = E262 E265 E266 E402 E501 E722
 
 [metadata]
 name = faraday


### PR DESCRIPTION
Travis CI showed E722 failing which is weird because nothing changed about it.. This also passes without the ignore for E722 when run locally with pytest. We should however ignore it because we haven't fully checked for this and one day will. I don't really understand how this was missed prior haha.

E722 is the use of a bare exception. I avoid it in most places though there are a few spot in my code I still use it. Some of our very old code is full of them however.

@reillyeon @kb1lqd 