### PR TITLE
Create Proxy Queues Upon Request

### DIFF
--- a/faraday/proxy.py
+++ b/faraday/proxy.py
@@ -297,8 +297,6 @@ def uart_worker(modem, getDicts, postDicts, units, log):
         # Place data into the FIFO coming from UART
         try:
             for port in modem['com'].RxPortListOpen():
-
-
                 if(modem['com'].RxPortHasItem(port)):
                     for i in range(0, modem['com'].RxPortItemCount(port)):
                         # Data is available

--- a/faraday/proxy.py
+++ b/faraday/proxy.py
@@ -686,8 +686,12 @@ def proxy():
         try:
             data = request.get_json(force=False)  # Requires HTTP JSON header
             port = request.args.get("port")
-            callsign = request.args.get("callsign").upper()
+            callsign = request.args.get("callsign")
             nodeid = request.args.get("nodeid")
+
+            # Convert callsign to uppercase
+            if callsign:
+                callsign = callsign.upper()
 
             # Check for parameters and ensure all required are present and of
             # acceptable values
@@ -768,10 +772,10 @@ def proxy():
     else:
         # This is the GET routine to return data to the user
         try:
-            port = request.args.get("port")
+            port = request.args.get("port", None)
             limit = request.args.get("limit", 100)
-            callsign = request.args.get("callsign").upper()
-            nodeid = request.args.get("nodeid")
+            callsign = request.args.get("callsign", None)
+            nodeid = request.args.get("nodeid", None)
 
         except ValueError as e:
             logger.error("ValueError: " + str(e))
@@ -782,6 +786,10 @@ def proxy():
         except KeyError as e:
             logger.error("KeyError: " + str(e))
             return json.dumps({"error": str(e)}), 400
+
+        # Convert callsign to uppercase
+        if callsign:
+            callsign = callsign.upper()
 
         # Check to see that required parameters are present
         try:

--- a/faraday/proxy.py
+++ b/faraday/proxy.py
@@ -685,9 +685,9 @@ def proxy():
 
         try:
             data = request.get_json(force=False)  # Requires HTTP JSON header
-            port = request.args.get("port")
-            callsign = request.args.get("callsign")
-            nodeid = request.args.get("nodeid")
+            port = request.args.get("port", None)
+            callsign = request.args.get("callsign", None)
+            nodeid = request.args.get("nodeid", None)
 
             # Convert callsign to uppercase
             if callsign:

--- a/faraday/proxy.py
+++ b/faraday/proxy.py
@@ -298,6 +298,7 @@ def uart_worker(modem, getDicts, postDicts, units, log):
         try:
             for port in modem['com'].RxPortListOpen():
 
+
                 if(modem['com'].RxPortHasItem(port)):
                     for i in range(0, modem['com'].RxPortItemCount(port)):
                         # Data is available
@@ -824,11 +825,8 @@ def proxy():
             try:
                 getDicts[station][port]
             except KeyError as e:
-                message = "KeyError: " +\
-                    "Callsign '{0}' or Port '{1}' does not exist"\
-                    .format(station, port)
-                logger.error(message)
-                return json.dumps({"error": message}), 400
+                # Create deque for port of requested station
+                getDicts[station][port] = deque([])
 
             if limit is None:
                 # Optional
@@ -865,7 +863,6 @@ def proxy():
                     data.append(packet)
                     if len(data) >= limit:
                         break
-
                 return json.dumps(data, indent=1), 200,\
                     {'Content-Type': 'application/json'}
             else:

--- a/faraday/proxy.py
+++ b/faraday/proxy.py
@@ -756,6 +756,12 @@ def proxy():
             logger.error("Error: No 'data' key in dictionary")
             return json.dumps(
                 {"error": "Error: No 'data' key in dictionary"}), 400
+
+        except TypeError:
+            logger.error("Error: No data provided in POST")
+            return json.dumps(
+                {"error": "Error: No data provided in POST"}), 400
+
         else:
             total = len(data["data"])
             sent = 0


### PR DESCRIPTION
This is a simple PR that addresses #60 such that any valid port which is requested is created if it is not found. Simplifying the problem seemed to make sense here. This PR should also address #50 since that is the same problem as #60 but for POST requests.

## Changes

- Fixed a .upper() error when performing a POST/GET HTTP request without any callsign specified
- Added default `None` types to to GET and POST routine parameters
- Modified GET and POST routines to create dequeue for station/port that is queried
- Added a TypeError for POST requests when no data is provided with the request
- Ensured that even when UART Telemetry is disabled Proxy still receives RF data