### PR TITLE
Fix Device Configuration

### DIFF
--- a/faraday/configure.py
+++ b/faraday/configure.py
@@ -2,17 +2,16 @@ import subprocess
 import time
 
 
-
 def main():
     """Main function"""
     # Start proxy server
-    proxy = subprocess.Popen(["faraday-proxy", "--start"])
+    #proxy = subprocess.Popen(["faraday-proxy", "--start"])
     #proxy.communicate()
 
     time.sleep(2)
 
     # Start deviceconfiguration server
-    configuration = subprocess.Popen(["faraday-deviceconfiguration", "--start"])
+    #configuration = subprocess.Popen(["faraday-deviceconfiguration", "--start"])
     #configuration.communicate()
 
     time.sleep(2)

--- a/faraday/configure.py
+++ b/faraday/configure.py
@@ -1,0 +1,26 @@
+import subprocess
+import time
+
+
+
+def main():
+    """Main function"""
+    # Start proxy server
+    proxy = subprocess.Popen(["faraday-proxy", "--start"])
+    #proxy.communicate()
+
+    time.sleep(2)
+
+    # Start deviceconfiguration server
+    configuration = subprocess.Popen(["faraday-deviceconfiguration", "--start"])
+    #configuration.communicate()
+
+    time.sleep(2)
+
+    # Start simpleconfig server
+    simpleconfig = subprocess.Popen(["faraday-simpleconfig", "--read", "--start"])
+    simpleconfig.communicate()
+
+
+if __name__ == '__main__':
+    main()

--- a/faraday/deviceconfiguration.py
+++ b/faraday/deviceconfiguration.py
@@ -49,8 +49,6 @@ parser = argparse.ArgumentParser(description='Device Configuration application p
 parser.add_argument('--init-config', dest='init', action='store_true', help='Initialize Device Configuration configuration file')
 parser.add_argument('--init-faraday-config', dest='initfaraday', action='store_true', help='Initialize Faraday configuration file')
 parser.add_argument('--start', action='store_true', help='Start Device Configuration server')
-parser.add_argument('--proxycallsign', help='Set Proxy Faraday callsign to connect to and program')
-parser.add_argument('--proxynodeid', type=int, help='Set Proxy Faraday nodeid to connect to and program')
 parser.add_argument('--faradayconfig', action='store_true', help='Display Faraday configuration file contents')
 
 # Faraday Configuration

--- a/faraday/deviceconfiguration.py
+++ b/faraday/deviceconfiguration.py
@@ -96,9 +96,11 @@ parser.add_argument('--rfinterval', type=int, help='Set Faraday radio RF telemet
 # Parse the arguments
 args = parser.parse_args()
 
+
 def proxyConfig(host, port):
-    r = requests.get("http://{0}:{1}/config".format(host,port))
+    r = requests.get("http://{0}:{1}/config".format(host, port))
     return r.json()
+
 
 def initializeDeviceConfigurationConfig():
     '''
@@ -195,7 +197,7 @@ def configureDeviceConfiguration(args, faradayConfigPath):
 
     # Obtain proxy configuration
     # TODO: Not hardcode
-    proxyConfiguration = proxyConfig("127.0.0.1",8000)
+    proxyConfiguration = proxyConfig("127.0.0.1", 8000)
 
     #Only works for UNIT0 at this time
     config.set('DEVICES', 'CALLSIGN', proxyConfiguration["UNIT0"].get("callsign"))
@@ -592,7 +594,7 @@ def main():
     deviceConfigHost = deviceConfigurationConfig.get("FLASK", "HOST")
     deviceConfigPort = deviceConfigurationConfig.getint("FLASK", "PORT")
 
-    proxyConfiguration = proxyConfig("127.0.0.1",8000)
+    #proxyConfiguration = proxyConfig("127.0.0.1", 8000)
 
     app.run(host=deviceConfigHost, port=deviceConfigPort, threaded=True)
 

--- a/faraday/deviceconfiguration.py
+++ b/faraday/deviceconfiguration.py
@@ -55,7 +55,7 @@ parser.add_argument('--faradayconfig', action='store_true', help='Display Farada
 
 # Faraday Configuration
 parser.add_argument('--callsign', help='Set Faraday radio callsign')
-parser.add_argument('--nodeid', type=int, help='Set Faraday radio nodeid')
+parser.add_argument('--nodeid', type=int, help='Set Faraday radio nodeid', default=1)
 parser.add_argument('--redledtxon', action='store_true', help='Set Faraday radio RED LED during RF transmissions ON')
 parser.add_argument('--redledtxoff', action='store_true', help='Set Faraday radio RED LED during RF transmissions OFF')
 parser.add_argument('--greenledrxon', action='store_true', help='Set Faraday radio GREEN LED during RF reception ON')
@@ -76,8 +76,8 @@ parser.add_argument('--gpiop5off', type=int, help='Set Faraday radio GPIO port 5
 parser.add_argument('--gpiop5clear', action='store_true', help='Reset Faraday radio GPIO port 5 bits to OFF')
 
 parser.add_argument('--gpiop5', type=int, help='Set Faraday radio fgpio_p5')
-parser.add_argument('--bootfrequency', type=float, help='Set Faraday radio boot frequency')
-parser.add_argument('--bootrfpower', type=int, help='Set Faraday radio boot RF power')
+parser.add_argument('--bootfrequency', type=float, help='Set Faraday radio boot frequency', default=914.5)
+parser.add_argument('--bootrfpower', type=int, help='Set Faraday radio boot RF power', default=20)
 parser.add_argument('--latitude', type=float, help='Set Faraday radio default latitude. Format \"ddmm.mmmm\"')
 parser.add_argument('--longitude', type=float, help='Set Faraday radio default longitude. Format \"dddmm.mmmm\"')
 parser.add_argument('--latitudedir', help='Set Faraday radio default latitude direction (N/S)')
@@ -92,12 +92,15 @@ parser.add_argument('--uarttelemetryenabled', action='store_true', help='Set Far
 parser.add_argument('--uarttelemetrydisabled', action='store_true', help='Set Faraday radio UART Telemetry OFF')
 parser.add_argument('--rftelemetryenabled', action='store_true', help='Set Faraday radio RF Telemetry ON')
 parser.add_argument('--rftelemetrydisabled', action='store_true', help='Set Faraday radio RF Telemetry OFF')
-parser.add_argument('--uartinterval', type=int, help='Set Faraday radio UART telemetry interval in seconds')
-parser.add_argument('--rfinterval', type=int, help='Set Faraday radio RF telemetry interval in seconds')
+parser.add_argument('--uartinterval', type=int, help='Set Faraday radio UART telemetry interval in seconds', default=5)
+parser.add_argument('--rfinterval', type=int, help='Set Faraday radio RF telemetry interval in seconds', default=3)
 
 # Parse the arguments
 args = parser.parse_args()
 
+def proxyConfig(host, port):
+    r = requests.get("http://{0}:{1}/config".format(host,port))
+    return r.json()
 
 def initializeDeviceConfigurationConfig():
     '''
@@ -193,10 +196,12 @@ def configureDeviceConfiguration(args, faradayConfigPath):
     fconfig.read(faradayConfigPath)
 
     # Obtain proxy configuration
-    if args.proxycallsign is not None:
-        config.set('DEVICES', 'CALLSIGN', args.proxycallsign)
-    if args.proxynodeid is not None:
-        config.set('DEVICES', 'NODEID', args.proxynodeid)
+    # TODO: Not hardcode
+    proxyConfiguration = proxyConfig("127.0.0.1",8000)
+
+    #Only works for UNIT0 at this time
+    config.set('DEVICES', 'CALLSIGN', proxyConfiguration["UNIT0"].get("callsign"))
+    config.set('DEVICES', 'NODEID', proxyConfiguration["UNIT0"].get("nodeid"))
 
     # Faraday radio configuration
     if args.callsign is not None:
@@ -588,6 +593,8 @@ def main():
     # Start the flask server
     deviceConfigHost = deviceConfigurationConfig.get("FLASK", "HOST")
     deviceConfigPort = deviceConfigurationConfig.getint("FLASK", "PORT")
+
+    proxyConfiguration = proxyConfig("127.0.0.1",8000)
 
     app.run(host=deviceConfigHost, port=deviceConfigPort, threaded=True)
 

--- a/faraday/proxy.py
+++ b/faraday/proxy.py
@@ -667,6 +667,24 @@ def bufferWorker(modem, postDicts, dataBuffer, payloadSize):
 # Initialize Flask microframework
 app = Flask(__name__)
 
+@app.route('/config', methods=['GET'])
+def config():
+    """
+    Provides a RESTful interface to Proxy configuration'
+
+    Returns Proxy configuratation
+    """
+    if request.method == "GET":
+        sections = proxyConfig.sections()
+        matching = (s for s in sections if "UNIT" in s)
+        temp = {}
+        for item in matching:
+            temp[item] = {}
+            temp[item]["callsign"] = proxyConfig.get(item, "callsign")
+            temp[item]["nodeid"] = proxyConfig.getint(item, "nodeid")
+        return json.dumps(temp, indent=1), 200,\
+            {'Content-Type': 'application/json'}
+
 
 @app.route('/', methods=['GET', 'POST'])
 def proxy():

--- a/faraday/proxy.py
+++ b/faraday/proxy.py
@@ -667,6 +667,7 @@ def bufferWorker(modem, postDicts, dataBuffer, payloadSize):
 # Initialize Flask microframework
 app = Flask(__name__)
 
+
 @app.route('/config', methods=['GET'])
 def config():
     """

--- a/faraday/telemetry.py
+++ b/faraday/telemetry.py
@@ -165,7 +165,7 @@ def showTelemetryLogs():
 
 
 def proxyConfig(host, port):
-    r = requests.get("http://{0}:{1}/config".format(host,port))
+    r = requests.get("http://{0}:{1}/config".format(host, port))
     return r.json()
 
 
@@ -179,10 +179,10 @@ def configureTelemetry(args):
 
     config = ConfigParser.RawConfigParser()
     config.read(os.path.join(faradayHelper.path, configFile))
-    
+
     # Obtain proxy configuration
     # TODO: Not hardcode
-    proxyConfiguration = proxyConfig("127.0.0.1",8000)
+    proxyConfiguration = proxyConfig("127.0.0.1", 8000)
 
     # Configure UNITx sections
     unit = 'UNIT' + str(args.unit)

--- a/faraday/telemetry.py
+++ b/faraday/telemetry.py
@@ -183,10 +183,7 @@ def configureTelemetry(args):
     # Obtain proxy configuration
     # TODO: Not hardcode
     proxyConfiguration = proxyConfig("127.0.0.1",8000)
-    
-    logger.warning(proxyConfiguration["UNIT0"].get("callsign"))
-    logger.warning(proxyConfiguration["UNIT0"].get("nodeid"))
-    
+
     # Configure UNITx sections
     unit = 'UNIT' + str(args.unit)
     if args.unit is not 0:

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,7 +10,7 @@ summary = FaradayRF amateur radio open source software
 description-file = README
 home-page = https://github.com/FaradayRF/Faraday-Software
 license = GPLv3
-version = 0.0.1017
+version = 0.0.1018
 classifier =
     "Development Status :: 2 - Pre-Alpha"
     "Framework :: Flask"


### PR DESCRIPTION
This PR incorporates items from #105 and addresses the following items

- Fixes the POST, GET, and GETwait hard-coded host/port error that prevents units from being configured
- implements '/configure' URL in proxy so applications such as telemetry and device configuration automatically connect to the correct unit on proxy
- adds some subprocess commands (in work) that could help in the future to make software easier to use.

This is sort of a quick bug fix for configuration. Not much more.